### PR TITLE
Object.observe is being deprecated

### DIFF
--- a/subscriptions.js
+++ b/subscriptions.js
@@ -25,20 +25,13 @@ var setSubscriptions = function () {
   SubscriptionsDict.set("Constellation_subscriptions", subKeys);
 }
 
-if (Object.observe) {
-  Object.observe(Meteor.default_connection._subscriptions, function () {
+// Poll subscriptions on this connection
+Meteor.setInterval(function () {
+  var currentTab = Constellation.getCurrentTab();
+  if (currentTab && currentTab.id === 'Subscriptions') {
     setSubscriptions();
-  });
-}
-else {
-  // Poll subscriptions on this connection
-  Meteor.setInterval(function () {
-    var currentTab = Constellation.getCurrentTab();
-    if (currentTab && currentTab.id === 'Subscriptions') {
-      setSubscriptions();
-    }
-  },3000);
-}
+  }
+},3000);
 
 Template.Constellation_subscriptions_main.helpers({
   subscriptions: function () {


### PR DESCRIPTION
I started seeing this warning in my Meteor app:

```
'Object.observe' is deprecated and will be removed in M50, around April 2016. See https://www.chromestatus.com/features/6147094632988672 for more details.
```

I went ahead and took the liberty of removing this.
